### PR TITLE
Fix/missing events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -115,7 +115,11 @@ func New(objectMeta metaV1.ObjectMeta, object interface{}, eventType config.Even
 		event.Level = LevelMap[config.EventType(strings.ToLower(eventObj.Type))]
 		event.Count = eventObj.Count
 		event.Action = eventObj.Action
-		event.TimeStamp = eventObj.LastTimestamp.Time
+		if eventObj.LastTimestamp.IsZero() {
+			event.TimeStamp = eventObj.EventTime.Time
+		} else {
+			event.TimeStamp = eventObj.LastTimestamp.Time  // This is the bugging timestamp
+		}
 		// Compatible with events.k8s.io/v1
 		if eventObj.LastTimestamp.IsZero() && eventObj.Series != nil {
 			event.TimeStamp = eventObj.Series.LastObservedTime.Time

--- a/pkg/utils/jsonpath.go
+++ b/pkg/utils/jsonpath.go
@@ -19,6 +19,8 @@ func parseJsonpath(obj interface{}, jsonpathStr string) (string, error) {
 	if err := j.Parse(fields); err != nil {
 		return "", err
 	}
+	
+	j = j.AllowMissingKeys(true)
 
 	values, err := j.FindResults(obj)
 	if err != nil {


### PR DESCRIPTION
- Fetch an event timestamp from other sources if it is null in the usual one. This fixes events with null timestamp that elastic search don't index properly.
- Allow missing keys in the objects json to detect events updates where the key actually appears later on.